### PR TITLE
docs: zsh-abbr のインストール手順を追加

### DIFF
--- a/docs/zsh.md
+++ b/docs/zsh.md
@@ -17,3 +17,13 @@ chsh -s $(which zsh)
 ```bash
 exec $SHELL -l
 ```
+
+## zsh-abbr
+
+- 参考: https://zsh-abbr.olets.dev/
+
+### インストール
+
+```bash
+git clone --recurse-submodules https://github.com/olets/zsh-abbr ~/.local/share/zsh-abbr
+```

--- a/docs/zsh.md
+++ b/docs/zsh.md
@@ -25,5 +25,5 @@ exec $SHELL -l
 ### インストール
 
 ```bash
-git clone --recurse-submodules https://github.com/olets/zsh-abbr ~/.local/share/zsh-abbr
+mkdir -p ~/.local/share && git clone --recurse-submodules https://github.com/olets/zsh-abbr ~/.local/share/zsh-abbr
 ```


### PR DESCRIPTION
## Summary
- zsh-abbr のインストール手順と参考URLを `docs/zsh.md` に追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)